### PR TITLE
Add various timers

### DIFF
--- a/vc/action.go
+++ b/vc/action.go
@@ -60,7 +60,8 @@ func RegisterCriteriaTransformer(transformer func(*ctx.Context, *Criteria)) {
 }
 
 // HTTPHandler takes an ActionHandler and returns a http.Handler instance
-// that can be used.
+// that can be used. The type and action are used to determine the context in
+// several areas, such as transformers and metrics.
 func (p *ActionProcessor) HTTPHandler(typ, action string, handler ActionHandler) httprouter.Handle {
 	// Create a new timer for timing this handler.
 	timer := metrics.NewTimer()

--- a/vc/action.go
+++ b/vc/action.go
@@ -25,6 +25,13 @@ const (
 // through to unlocking, and responding.
 type ActionProcessor struct {
 	SideloadEnabled bool
+	MetricsRegistry metrics.Registry
+}
+
+func NewActionProcessor() *ActionProcessor {
+	return &ActionProcessor{
+		MetricsRegistry: metrics.NewRegistry(),
+	}
 }
 
 // ActionHandler implementers are responsible for returning payload data for
@@ -65,11 +72,11 @@ func RegisterCriteriaTransformer(transformer func(*ctx.Context, *Criteria)) {
 func (p *ActionProcessor) HTTPHandler(typ, action string, handler ActionHandler) httprouter.Handle {
 	// Create a new timer for timing this handler.
 	timer := metrics.NewTimer()
-	metrics.DefaultRegistry.Register(typ+"-"+action, timer)
+	p.MetricsRegistry.Register(typ+"-"+action, timer)
 	sideloadTimer := metrics.NewTimer()
-	metrics.DefaultRegistry.Register(typ+"-"+action+"-sideload", sideloadTimer)
+	p.MetricsRegistry.Register(typ+"-"+action+"-sideload", sideloadTimer)
 	unlockTimer := metrics.NewTimer()
-	metrics.DefaultRegistry.Register(typ+"-"+action+"-unlock", unlockTimer)
+	p.MetricsRegistry.Register(typ+"-"+action+"-unlock", unlockTimer)
 
 	return httprouter.Handle(func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		// At the end of this function, add a time metric.


### PR DESCRIPTION
This allows us to have timed metrics based on the type of entity and action being performed. Includes a breaking api change.
