### PR TITLE
Allow explicit exclusion or inclusion of fields inc structs

### DIFF
--- a/changes/changes_test.go
+++ b/changes/changes_test.go
@@ -17,6 +17,12 @@ type TestStruct struct {
 	FloatPtrField  *float64   `json:"float_ptr_field"`
 	BoolField      bool       `json:"bool_field"`
 	BoolPtrField   *bool      `json:"bool_ptr_field"`
+	ExcludedStruct struct {
+		ExcludedField string
+	} `diff:"exclude"`
+	IncludedStruct struct {
+		IncludedField string
+	} `diff:"include"`
 }
 
 var testDiffer = Differ{
@@ -58,6 +64,7 @@ func TestPlainStructDiff(t *testing.T) {
 		TimeField:      now,
 		TimePtrField:   &now,
 	}
+	old.IncludedStruct.IncludedField = foo
 	then := time.Now()
 	new := TestStruct{
 		StringField:    bar,
@@ -65,11 +72,13 @@ func TestPlainStructDiff(t *testing.T) {
 		TimeField:      then,
 		TimePtrField:   &then,
 	}
+	new.IncludedStruct.IncludedField = bar
+
 	diffs, err := testDiffer.Between(old, new)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	if len(diffs) != 4 {
+	if len(diffs) != 5 {
 		t.Errorf("Unexpected diff count: %d, expected 4", len(diffs))
 	}
 	for _, expectedDiff := range []Diff{
@@ -77,6 +86,7 @@ func TestPlainStructDiff(t *testing.T) {
 		{"string_ptr_field", "foo", "bar"},
 		{"time_field", now, then},
 		{"time_ptr_field", now, then},
+		{"IncludedStruct.IncludedField", "foo", "bar"},
 	} {
 		resultDiff, ok := diffs[expectedDiff.Key]
 		if !ok {

--- a/changes/mapper_test.go
+++ b/changes/mapper_test.go
@@ -9,20 +9,27 @@ import (
 )
 
 type TestMappingStruct struct {
-	NoTag     string
-	JSONTag   string `json:"json_tag"`
-	DBTag     string `db:"db_tag"`
-	BothTag   string `json:"both_tag_json" db:"both_tag_db"`
-	String    string
-	StringPtr *string
-	Time      time.Time
-	TimePtr   *time.Time
-	Int       int
-	IntPtr    *int
-	Float     float64
-	FloatPtr  *float64
-	Bool      bool
-	BoolPtr   *bool
+	NoTag          string
+	JSONTag        string `json:"json_tag"`
+	DBTag          string `db:"db_tag"`
+	BothTag        string `json:"both_tag_json" db:"both_tag_db"`
+	String         string
+	StringPtr      *string
+	Time           time.Time
+	TimePtr        *time.Time
+	Int            int
+	IntPtr         *int
+	Float          float64
+	FloatPtr       *float64
+	Bool           bool
+	BoolPtr        *bool
+	ExcludedStruct struct {
+		ExcludedField string
+	} `diff:"exclude"`
+	IncludedStruct struct {
+		IncludedField string
+		NoTag         string
+	} `diff:"include"`
 }
 
 func TestTagMapping(t *testing.T) {
@@ -30,20 +37,22 @@ func TestTagMapping(t *testing.T) {
 	data := TestMappingStruct{}
 	val := reflect.ValueOf(data)
 	expected := map[string][]int{
-		"NoTag":       {0},
-		"json_tag":    {1},
-		"db_tag":      {2},
-		"both_tag_db": {3},
-		"String":      {4},
-		"StringPtr":   {5},
-		"Time":        {6},
-		"TimePtr":     {7},
-		"Int":         {8},
-		"IntPtr":      {9},
-		"Float":       {10},
-		"FloatPtr":    {11},
-		"Bool":        {12},
-		"BoolPtr":     {13},
+		"NoTag":                        {0},
+		"json_tag":                     {1},
+		"db_tag":                       {2},
+		"both_tag_db":                  {3},
+		"String":                       {4},
+		"StringPtr":                    {5},
+		"Time":                         {6},
+		"TimePtr":                      {7},
+		"Int":                          {8},
+		"IntPtr":                       {9},
+		"Float":                        {10},
+		"FloatPtr":                     {11},
+		"Bool":                         {12},
+		"BoolPtr":                      {13},
+		"IncludedStruct.IncludedField": {15, 0},
+		"IncludedStruct.NoTag":         {15, 1},
 	}
 	result, err := mapper.KeyIndexes(val)
 	if err != nil {


### PR DESCRIPTION
This allows inclusion of struct's in the `changes` package for diffing.

``` go
type TestMappingStruct struct {
    ExcludedStruct struct {
        ExcludedField string
    } `diff:"exclude"`
    IncludedStruct struct {
        IncludedField string
        NoTag         string
    } `diff:"include"`
}
```
