### PR TITLE
Nested struct diff changes

### DIFF
--- a/changes/mapper_test.go
+++ b/changes/mapper_test.go
@@ -30,6 +30,9 @@ type TestMappingStruct struct {
 		IncludedField string
 		NoTag         string
 	} `diff:"include"`
+	IncludedStructSingleField struct {
+		IncludedField string
+	} `diff:"include"`
 }
 
 func TestTagMapping(t *testing.T) {
@@ -53,6 +56,7 @@ func TestTagMapping(t *testing.T) {
 		"BoolPtr":                      {13},
 		"IncludedStruct.IncludedField": {15, 0},
 		"IncludedStruct.NoTag":         {15, 1},
+		"IncludedStructSingleField":    {16, 0},
 	}
 	result, err := mapper.KeyIndexes(val)
 	if err != nil {

--- a/changes/struct_diff_test.go
+++ b/changes/struct_diff_test.go
@@ -22,6 +22,7 @@ type TestStruct struct {
 	} `diff:"exclude"`
 	IncludedStruct struct {
 		IncludedField string
+		NoTag         string
 	} `diff:"include"`
 }
 

--- a/lynx/float.go
+++ b/lynx/float.go
@@ -9,7 +9,7 @@ import (
 
 // EncryptedFloat represents a float that is encryptable as a string.
 type EncryptedFloat struct {
-	Str *string
+	StringValue *string
 }
 
 // NewEncryptedFloat returns a newly initialized EncryptedFloat.
@@ -22,15 +22,15 @@ func NewEncryptedFloat(f float64) EncryptedFloat {
 // SetFloat updates the underlying float value.
 func (ef *EncryptedFloat) SetFloat(f float64) {
 	s := fmt.Sprintf("%g", f)
-	ef.Str = &s
+	ef.StringValue = &s
 }
 
 // Float64 returns a float64 representation of the EncryptedFloat.
 func (ef *EncryptedFloat) Float64() (float64, error) {
-	if ef.Str == nil {
+	if ef.StringValue == nil {
 		return 0, fmt.Errorf("EncryptedFloat.Float64: attempting to return nil float64")
 	}
-	return strconv.ParseFloat(*ef.Str, 64)
+	return strconv.ParseFloat(*ef.StringValue, 64)
 }
 
 // UnmarshalJSON will unmarshall a raw json representation of a number into an EncryptedFloat.
@@ -43,13 +43,13 @@ func (ef *EncryptedFloat) UnmarshalJSON(raw []byte) error {
 	}
 	// Use the unmarshaled float value.
 	s := fmt.Sprintf("%g", f)
-	ef.Str = &s
+	ef.StringValue = &s
 	return nil
 }
 
 // MarshalJSON marshals the current value into a json number.
 func (ef EncryptedFloat) MarshalJSON() ([]byte, error) {
-	if ef.Str == nil {
+	if ef.StringValue == nil {
 		return []byte("null"), nil
 	}
 	// Convert to float if possible.
@@ -63,15 +63,15 @@ func (ef EncryptedFloat) MarshalJSON() ([]byte, error) {
 
 // EncryptableString returns the underlying string pointer.
 func (ef EncryptedFloat) EncryptableString() *string {
-	return ef.Str
+	return ef.StringValue
 }
 
 // String implements the stringer interface.
 func (ef EncryptedFloat) String() string {
-	if ef.Str == nil {
+	if ef.StringValue == nil {
 		return ""
 	}
-	return *ef.Str
+	return *ef.StringValue
 }
 
 // Scan implements sql.Scanner for scanning database values.
@@ -79,17 +79,17 @@ func (ef *EncryptedFloat) Scan(value interface{}) error {
 	switch val := value.(type) {
 	case float64:
 		s := fmt.Sprintf("%f", val)
-		ef.Str = &s
+		ef.StringValue = &s
 	case int64:
 		s := fmt.Sprintf("%d", val)
-		ef.Str = &s
+		ef.StringValue = &s
 	case []byte:
 		s := string(val)
 		ef.Str = &s
 	case string:
-		ef.Str = &val
+		ef.StringValue = &val
 	case nil:
-		ef.Str = nil
+		ef.StringValue = nil
 	default:
 		return fmt.Errorf("EncryptedFloat.Scan: invalid scan type %T", value)
 	}
@@ -98,8 +98,8 @@ func (ef *EncryptedFloat) Scan(value interface{}) error {
 
 // Value implements value.Valuer to provide database values.
 func (ef EncryptedFloat) Value() (driver.Value, error) {
-	if ef.Str == nil {
+	if ef.StringValue == nil {
 		return nil, nil
 	}
-	return *ef.Str, nil
+	return *ef.StringValue, nil
 }

--- a/lynx/float.go
+++ b/lynx/float.go
@@ -9,7 +9,7 @@ import (
 
 // EncryptedFloat represents a float that is encryptable as a string.
 type EncryptedFloat struct {
-	str *string
+	Str *string
 }
 
 // NewEncryptedFloat returns a newly initialized EncryptedFloat.
@@ -22,15 +22,15 @@ func NewEncryptedFloat(f float64) EncryptedFloat {
 // SetFloat updates the underlying float value.
 func (ef *EncryptedFloat) SetFloat(f float64) {
 	s := fmt.Sprintf("%g", f)
-	ef.str = &s
+	ef.Str = &s
 }
 
 // Float64 returns a float64 representation of the EncryptedFloat.
 func (ef *EncryptedFloat) Float64() (float64, error) {
-	if ef.str == nil {
+	if ef.Str == nil {
 		return 0, fmt.Errorf("EncryptedFloat.Float64: attempting to return nil float64")
 	}
-	return strconv.ParseFloat(*ef.str, 64)
+	return strconv.ParseFloat(*ef.Str, 64)
 }
 
 // UnmarshalJSON will unmarshall a raw json representation of a number into an EncryptedFloat.
@@ -43,17 +43,17 @@ func (ef *EncryptedFloat) UnmarshalJSON(raw []byte) error {
 	}
 	// Use the unmarshaled float value.
 	s := fmt.Sprintf("%g", f)
-	ef.str = &s
+	ef.Str = &s
 	return nil
 }
 
 // MarshalJSON marshals the current value into a json number.
 func (ef EncryptedFloat) MarshalJSON() ([]byte, error) {
-	if ef.str == nil {
+	if ef.Str == nil {
 		return []byte("null"), nil
 	}
 	// Convert to float if possible.
-	f, err := strconv.ParseFloat(*ef.str, 64)
+	f, err := strconv.ParseFloat(*ef.Str, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to convert encrypted float to float: %s", err)
 	}
@@ -63,15 +63,15 @@ func (ef EncryptedFloat) MarshalJSON() ([]byte, error) {
 
 // EncryptableString returns the underlying string pointer.
 func (ef EncryptedFloat) EncryptableString() *string {
-	return ef.str
+	return ef.Str
 }
 
 // String implements the stringer interface.
 func (ef EncryptedFloat) String() string {
-	if ef.str == nil {
+	if ef.Str == nil {
 		return ""
 	}
-	return *ef.str
+	return *ef.Str
 }
 
 // Scan implements sql.Scanner for scanning database values.
@@ -79,17 +79,17 @@ func (ef *EncryptedFloat) Scan(value interface{}) error {
 	switch val := value.(type) {
 	case float64:
 		s := fmt.Sprintf("%f", val)
-		ef.str = &s
+		ef.Str = &s
 	case int64:
 		s := fmt.Sprintf("%d", val)
-		ef.str = &s
+		ef.Str = &s
 	case []byte:
 		s := string(val)
-		ef.str = &s
+		ef.Str = &s
 	case string:
-		ef.str = &val
+		ef.Str = &val
 	case nil:
-		ef.str = nil
+		ef.Str = nil
 	default:
 		return fmt.Errorf("EncryptedFloat.Scan: invalid scan type %T", value)
 	}
@@ -98,8 +98,8 @@ func (ef *EncryptedFloat) Scan(value interface{}) error {
 
 // Value implements value.Valuer to provide database values.
 func (ef EncryptedFloat) Value() (driver.Value, error) {
-	if ef.str == nil {
+	if ef.Str == nil {
 		return nil, nil
 	}
-	return *ef.str, nil
+	return *ef.Str, nil
 }


### PR DESCRIPTION
- Changed `lynx.EncryptedFloat` to have an underlying exported value, otherwise a diff would not be returned on the struct due to: [#L64](https://github.com/snikch/api/blob/master/changes/mapper.go#L64)
- If a given struct being diff'd (enforced via `diff:"include"`) is found to have a single field, the name is returned without appending the field-name. 

For example:

```
type TestStruct struct {
    MyEncryptedFloaty lynx.NewEncryptedFloat `json:"amount" diff:"include"`
}

"amount": {
            "field": "amount",
            "from": "110000",
            "to": "115000"
},
```

If given struct being diff'd has more than one field, values will continue to be returned prefixed.
