### PR TITLE
Auth Err - Internal Codes

### DIFF
--- a/fail/auth.go
+++ b/fail/auth.go
@@ -3,6 +3,7 @@ package fail
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // AuthenticationError represents a failure to authenticate.
@@ -21,11 +22,17 @@ func NewAuthError(code int, parts ...string) AuthenticationError {
 		description = parts[1]
 	}
 
+	// Map our custom auth error code.
+	internalErrCode := map[string]string{
+		"internal_error_code": strconv.Itoa(code),
+	}
+
 	return AuthenticationError{
 		Err: Err{
-			Code:          code,
-			OriginalError: fmt.Errorf(err),
-			Description:   description,
+			Code:             code,
+			OriginalError:    fmt.Errorf(err),
+			Description:      description,
+			AdditionalFields: internalErrCode,
 		},
 	}
 }

--- a/fail/auth.go
+++ b/fail/auth.go
@@ -24,7 +24,7 @@ func NewAuthError(code int, parts ...string) AuthenticationError {
 
 	// Map our custom auth error code.
 	internalErrCode := map[string]string{
-		"internal_error_code": strconv.Itoa(code),
+		"error_code": strconv.Itoa(code),
 	}
 
 	return AuthenticationError{


### PR DESCRIPTION
Authentication errors now handle `code` passed and return within `Err.AdditionalFields` map.

**Context:**

Frontend needs a way to distinguish between authentication errors (eg: expired, invalid, malformed tokens), while still parsing/handling the `401` status code first.

**Example:**

```
ErrNoIcecream = fail.NewAuthError(422001, "No Icecream Available", noIcecreamDescription)
```

```
401 Unauthorized
{
  "error": "No Icecream Available",
  "description": "It seems all icecream has melted. This is not good. Please check your local Mr Whippey and try again.",
  "fields": {
    "internal_error_code": "422001"
  }
}
```
