### PR TITLE
NewPermissionError

### DIFF
--- a/fail/permission.go
+++ b/fail/permission.go
@@ -1,6 +1,10 @@
 package fail
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
 
 // PermissionsError represents a forbidden access request.
 type PermissionsError struct {
@@ -8,10 +12,27 @@ type PermissionsError struct {
 }
 
 // NewPermissionsError returns a new PermissionsError to wrap the supplied error.
-func NewPermissionsError(err error) PermissionsError {
+func NewPermissionsError(code int, parts ...string) PermissionsError {
+	var description, err string
+
+	if len(parts) >= 1 {
+		err = parts[0]
+	}
+	if len(parts) >= 2 {
+		description = parts[1]
+	}
+
+	// Map our custom permission error code.
+	internalErrCode := map[string]string{
+		"error_code": strconv.Itoa(code),
+	}
+
 	return PermissionsError{
 		Err: Err{
-			OriginalError: err,
+			Code:             code,
+			OriginalError:    fmt.Errorf(err),
+			Description:      description,
+			AdditionalFields: internalErrCode,
 		},
 	}
 }

--- a/fail/permission.go
+++ b/fail/permission.go
@@ -12,6 +12,8 @@ type PermissionsError struct {
 }
 
 // NewPermissionsError returns a new PermissionsError to wrap the supplied error.
+// The parts slice elements refer to the original error and a more detailed
+// description respectively.
 func NewPermissionsError(code int, parts ...string) PermissionsError {
 	var description, err string
 


### PR DESCRIPTION
**Potentially breaking changes**

This change allows us to pass a `code` and `description` to NewPermissionsError. This operates exactly the same way NewAuthError currently does.

This will allow the consumer to distinguish between different permission errors that could be returned.

@snikch Are you using `fail` anywhere else?



