### PR TITLE
Introduced mutex to ensure data is safe across multiple goroutines

### DIFF
--- a/changes/mapper.go
+++ b/changes/mapper.go
@@ -3,6 +3,7 @@ package changes
 import (
 	"reflect"
 	"strings"
+	"sync"
 )
 
 // KeyMapper defines an interface for finding the key name for a given type field.
@@ -17,6 +18,7 @@ type KeyMapper interface {
 type TagMapper struct {
 	tags  []string
 	types map[reflect.Type]KeyIndexes
+	sync.RWMutex
 }
 
 // KeyIndexes provides an ordered list of keys with their reflection indexes.
@@ -53,8 +55,10 @@ func (mapper *TagMapper) KeyIndexes(value reflect.Value) (KeyIndexes, error) {
 
 // registerValue will create an index lookup, save it for later use, and return it.
 func (mapper *TagMapper) registerValue(value reflect.Value) (KeyIndexes, error) {
+	mapper.Lock()
 	indexes := mapper.registerPart("", NewKeyIndexes(), value, []int{})
 	mapper.types[value.Type()] = indexes
+	mapper.Unlock()
 	return indexes, nil
 }
 

--- a/changes/mapper.go
+++ b/changes/mapper.go
@@ -47,10 +47,10 @@ func NewTagMapper(tags ...string) *TagMapper {
 // locations in the value's type.
 func (mapper *TagMapper) KeyIndexes(value reflect.Value) (KeyIndexes, error) {
 	mapper.RLock()
-	defer mapper.RUnlock()
-
 	typ := value.Type()
-	if indexes, ok := mapper.types[typ]; ok {
+	indexes, ok := mapper.types[typ]
+	mapper.RUnlock()
+	if ok {
 		return indexes, nil
 	}
 	return mapper.registerValue(value)

--- a/changes/mapper.go
+++ b/changes/mapper.go
@@ -46,6 +46,9 @@ func NewTagMapper(tags ...string) *TagMapper {
 // KeyIndexes implements the KeyMapper interface and returns the keys and their
 // locations in the value's type.
 func (mapper *TagMapper) KeyIndexes(value reflect.Value) (KeyIndexes, error) {
+	mapper.RLock()
+	defer mapper.RUnlock()
+
 	typ := value.Type()
 	if indexes, ok := mapper.types[typ]; ok {
 		return indexes, nil


### PR DESCRIPTION
### Description

We initialize a single `changes` instance for our event logging. 

We're now in the process of integrating with other services which pulls in data across multiple goroutines. Any resulting events being created during this process are getting stuck here (`fatal: concurrent map writes`).

This introduces a lock to ensure `changes.TagMapper` data is safe across goroutines.

### Also...

Welcome back mate! I hope you had a blast in Bali. Photos looked wicked. Looking forward to a catch-up and hearing all the _stories_.